### PR TITLE
* Updated Vault Ethereum Response Object

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -164,20 +164,25 @@ func (b *PluginBackend) pathWriteConfig(ctx context.Context, req *logical.Reques
 	entry, err := logical.StorageEntryJSON("config", configBundle)
 
 	if err != nil {
-		return nil, err
+		return util.ErrorResponse(err);
 	}
 
 	if err := req.Storage.Put(ctx, entry); err != nil {
-		return nil, err
+		return util.ErrorResponse(err);
 	}
 	// Return the secret
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"bound_cidr_list": configBundle.BoundCIDRList,
-			"inclusions":      configBundle.Inclusions,
-			"exclusions":      configBundle.Exclusions,
-			"rpc_url":         configBundle.RPC,
-			"chain_id":        configBundle.ChainID,
+			"data": map[string]interface{}{
+				"bound_cidr_list": configBundle.BoundCIDRList,
+				"inclusions":      configBundle.Inclusions,
+				"exclusions":      configBundle.Exclusions,
+				"rpc_url":         configBundle.RPC,
+				"chain_id":        configBundle.ChainID,
+			},
+			"code": 0,
+			"message": "Succesfull configuration change.",
+			
 		},
 	}, nil
 }
@@ -185,7 +190,7 @@ func (b *PluginBackend) pathWriteConfig(ctx context.Context, req *logical.Reques
 func (b *PluginBackend) pathReadConfig(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	configBundle, err := b.readConfig(ctx, req.Storage)
 	if err != nil {
-		return nil, err
+		return util.ErrorResponse(err);
 	}
 
 	if configBundle == nil {
@@ -195,11 +200,15 @@ func (b *PluginBackend) pathReadConfig(ctx context.Context, req *logical.Request
 	// Return the secret
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"bound_cidr_list": configBundle.BoundCIDRList,
-			"inclusions":      configBundle.Inclusions,
-			"exclusions":      configBundle.Exclusions,
-			"rpc_url":         configBundle.RPC,
-			"chain_id":        configBundle.ChainID,
+			"data": map[string]interface{}{
+				"bound_cidr_list": configBundle.BoundCIDRList,
+				"inclusions":      configBundle.Inclusions,
+				"exclusions":      configBundle.Exclusions,
+				"rpc_url":         configBundle.RPC,
+				"chain_id":        configBundle.ChainID,
+			},
+			"code": 0,
+			"message": "Succesfull configuration query.",
 		},
 	}, nil
 }

--- a/scripts/deploy_plugin.sh
+++ b/scripts/deploy_plugin.sh
@@ -16,10 +16,9 @@ prompt_if_missing() {
 }
 
 # Prompt for missing variables
+prompt_if_missing "VAULT_TOKEN" "Enter vault token with required capabilities: " ""
 prompt_if_missing "PLUGIN_BINARY_PATH" "Enter the path to the plugin binary: " ""
 prompt_if_missing "VAULT_CONTAINER_ID" "Enter the Vault container ID or name: " ""
-prompt_if_missing "VAULT_USERNAME" "Enter the Vault username: " ""
-prompt_if_missing "VAULT_PASSWORD" "Enter the Vault password: " ""
 prompt_if_missing "VAULT_ADDR" "Enter the Vault address: " ""
 prompt_if_missing "PLUGIN_SHA256" "Enter the plugin binary SHA256 checksum: " ""
 prompt_if_missing "PLUGIN_VERSION" "Enter the plugin version: " ""
@@ -44,15 +43,6 @@ docker exec "${VAULT_CONTAINER_ID}" /bin/sh -c "
 # Step 3: Prepare the environment and register the plugin
 echo "Setting Vault environment variables..."
 export VAULT_SKIP_VERIFY=true
-
-echo "Logging into Vault as ${VAULT_USERNAME}..."
-vault login -method=userpass username="${VAULT_USERNAME}" password="${VAULT_PASSWORD}"
-
-# Check if login was successful
-if [ $? -ne 0 ]; then
-  echo "Failed to log into Vault."
-  exit 1
-fi
 
 echo "Registering the plugin with Vault..."
 

--- a/util/utilities.go
+++ b/util/utilities.go
@@ -343,3 +343,13 @@ func TokenAmount(amount int64, decimals uint8) *big.Int {
 	var bigProduct = new(big.Int)
 	return bigProduct.Mul(bigPower, bigAmount)
 }
+
+func ErrorResponse(err error) (*logical.Response, error) {
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"data":    nil,
+			"code":    1,
+			"message": err.Error(),
+		},
+	}, nil
+}


### PR DESCRIPTION
Code ve message alanlarının da data içinde bulunması Vault ve Vault Ethereum arasındaki iletişimin standardına uymak için koyuldu.

Örnek başarısız erc20/transfer response'u:
```json
{
    "request_id": "c3728bbd-adf5-10e4-79e9-cf6edb18a187",
    "lease_id": "",
    "renewable": false,
    "lease_duration": 0,
    "data": {
        "code": 1,
        "data": null,
        "message": "failed to estimate gas needed: insufficient funds for transfer"
    },
    "wrap_info": null,
    "warnings": null,
    "auth": null,
    "mount_type": "vault-ethereum"
}
```
Örnek başarılı erc20/tranfser response'u:
```json
{
    "request_id": "6f7de667-4423-ad6e-49a5-06fbb53fa95f",
    "lease_id": "",
    "renewable": false,
    "lease_duration": 0,
    "data": {
        "code": 0,
        "data": {
            "amount": "10000",
            "contract": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
            "from": "0xa05c5fF02B891b7AC7cde26D038A888aE44aB28C",
            "gas_limit": 47525,
            "gas_price": 174759143003,
            "name": "(PoS) Tether USD",
            "nonce": 179,
            "signed_transaction": "0xf8ac81b38528b074e65b82b9a594c2132d05d31c914a87c6611c10748aeb04b58e8f80b844a9059cbb000000000000000000000000c6bbdc9e3b123a748c9546cd96f8b76de114ac580000000000000000000000000000000000000000000000000000000000002710820135a05184119737b9b2bcf270a363435781ca8868c5011cbbf09900cb7e276b1b7e5fa06c8a7b947b5b7aa2a92e611141b8b423227a840951cbc237e70580f646715e24",
            "symbol": "USDT",
            "to": "0xc6BBDc9e3B123A748C9546cd96f8B76DE114aC58",
            "transaction_hash": "0xe7d20a84eb87a660ab58809c271ffadaeea67f974116b29349cb7bf01f262a06"
        },
        "message": "Successful transfer."
    },
    "wrap_info": null,
    "warnings": null,
    "auth": null,
    "mount_type": "vault-ethereum"
}
```